### PR TITLE
Update download_dataset.sh

### DIFF
--- a/NVIDIA/benchmarks/maskrcnn/implementations/download_dataset.sh
+++ b/NVIDIA/benchmarks/maskrcnn/implementations/download_dataset.sh
@@ -1,4 +1,4 @@
-wget https://s3-us-west-2.amazonaws.com/detectron/coco/coco_annotations_minival.tgz
+wget https://dl.fbaipublicfiles.com/detectron/coco/coco_annotations_minival.tgz
 wget http://images.cocodataset.org/zips/train2014.zip
 wget http://images.cocodataset.org/zips/val2014.zip
 wget http://images.cocodataset.org/annotations/annotations_trainval2014.zip


### PR DESCRIPTION
the old link is dead, doesn't allow downloading the dataset. Specifically, it produces the following output:

<img width="788" alt="Screen Shot 2020-07-09 at 1 57 16 PM" src="https://user-images.githubusercontent.com/44192460/86998804-1a8b4980-c1ec-11ea-93d9-e2eaf9d006b8.png">
