### PR TITLE
Update download_weights.sh

### DIFF
--- a/NVIDIA/benchmarks/maskrcnn/implementations/download_weights.sh
+++ b/NVIDIA/benchmarks/maskrcnn/implementations/download_weights.sh
@@ -1,1 +1,1 @@
-wget https://s3-us-west-2.amazonaws.com/detectron/ImageNetPretrained/MSRA/R-50.pkl
+wget https://dl.fbaipublicfiles.com/detectron/ImageNetPretrained/MSRA/R-50.pkl


### PR DESCRIPTION
The same issue as with download_dataset.sh - the file simply doesn't get downloaded. The updated link allows to get the weights file.